### PR TITLE
ホーム画面のレイアウト調整、日本語化修正

### DIFF
--- a/app/assets/stylesheets/_font.scss
+++ b/app/assets/stylesheets/_font.scss
@@ -1,5 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Zen+Maru+Gothic&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Cantata+One&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@200&display=swap');
 
 
 body {
@@ -18,4 +19,8 @@ body {
   font-size: 90px;
   font-family: 'Cantata One', serif;
   display: flex;
+}
+
+h2 {
+  font-family: 'Noto Serif JP', serif;
 }

--- a/app/assets/stylesheets/_style.scss
+++ b/app/assets/stylesheets/_style.scss
@@ -1,5 +1,58 @@
+:root {
+  --gray: #d9d9d9;
+  --box-shadow: 0 8px 22px rgba(0,0,0,0.2);
+}
+
+
 .top_image {
   width: 552px;
   height: 338px;
   flex-shrink: 0;
 }
+
+section {
+  padding-top: 120px;
+  padding-bottom: 120px;
+}
+
+
+.card-effect {
+  box-shadow: var(--box-shadow);
+  background-color: #fff;
+  padding: 25px;
+  transition: all 0.35s ease;
+}
+
+.card-effect:hover {
+  box-shadow: none;
+  transform: translateY(5px);
+}
+
+.content {
+  position: relative;
+  overflow: hidden;
+  border-radius: 17px;
+}
+
+.content::after {
+  content: "";
+  position: absolute;
+  top: -100%;
+  left:0;
+  background-color: var(--gray);
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  transition: all o.35s ease;
+  z-index: -1; 
+}
+
+
+
+.content:hover::after {
+  opacity: 1;
+  top: 0;
+}
+
+
+

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,4 @@
 @import "bootstrap";
 @import "font";
-@import "footer";
 @import "style";
+@import "footer";

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -1,10 +1,51 @@
 <div class = "container mt-5">
   <div class = "row justify-content-center">
-  <div class="d-flex flex-column justify-content-center" style="width: 379px; height: 154px;">
-        <h1 class = "top">Loguma<h1>
+      <div class="d-flex flex-column justify-content-center me-5 mt-5 col-md-8" style="width: 379px; height: 154px;">
+        <div class ="me-5">
+          <h1 class = "top">Loguma<h1>
+        </div>
+        <div class = "text-center mt-5">
+          <%=link_to 'Logをつける',new_user_path, class: "btn btn-secondary btn-lg" %>
+        </div>
       </div>
-      <div class= "col-5">
+      <div class= "col-5 ms-5">
         <%= image_tag 'book_top.png',size: "552x338",class: "rounded-3"%>
       </div>
   </div>
 </div>
+
+<!-- 説明セクション -->
+<section id ="content">
+<div class = "container text-center">
+  <div class = "row mx-auto col-10">
+    <div class = "col-md-8 mx-auto text-center">
+      <h2 class = "mb-5 title">Logumaで、ログをつける。身につける。</h2>
+    </div>
+  </div>
+</div>
+
+  <div class = "row g-4  mx-auto col-10">
+    <div class = "col-lg-4 col-sm-6 mx-auto">
+      <div class ="content card-effect text-center">
+        <h4 class = "mt-2 mb-4">課題に沿ったログをつける</h4>
+        <p>RUNTEQの課題に特化したログだから、</p>
+        <p>記録しやすい、管理しやすいを実現。</p>
+      </div>
+    </div>
+    <div class = "col-lg-4 col-sm-6 mx-auto">
+      <div class ="content card-effect text-center">
+        <h4 class = "mt-2 mb-4">学習時間を記録できる</h4>
+        <p>ログごとに時間を記録。</p>
+        <p>ログ１つにかかった時間が、すぐわかる。</p>
+      </div>
+    </div>
+    <div class = "col-lg-4 col-sm-6 mx-auto">
+      <div class ="content card-effect text-center">
+        <h4 class = "mt-2 mb-4">GitHubでも</h4>
+        <p>GitHubのアカウントでもログイン可能。</p>
+        <p>ひょっとしたら草が生える。</p>
+      </div>
+    </div>
+
+  </div>
+</section>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -23,13 +23,15 @@ ja:
         minutes: 分
         curriculum_id: 課題
         chapter_id: チャプター
+        curriculum: 課題
+        chapter: チャプター
       curriculum:
         name: 課題
       chapter:
         name: チャプター
-    helpers:
-      label:
-        curriculum_id: 課題
-        chapter_id: 章
-        email: メールアドレス
-        password: パスワード
+  helpers:
+    label:
+      curriculum_id: 課題
+      chapter_id: チャプター
+      email: メールアドレス
+      password: パスワード


### PR DESCRIPTION
## ホーム画面のレイアウト
[![Image from Gyazo](https://i.gyazo.com/dea780bd080c3f0c059bb8258b7bf032.gif)](https://gyazo.com/dea780bd080c3f0c059bb8258b7bf032)

## フォントのimport
グーグルフォントからNoto Sans Japaneseのフォント追加。
反映されなかったら、プリコンパイルしてください〜

## ja.ymlファイル修正
えみりちゃんありがとう

[![Image from Gyazo](https://i.gyazo.com/f8cc510e5ce8b7ae4cdbffbf4fdef6ff.png)](https://gyazo.com/f8cc510e5ce8b7ae4cdbffbf4fdef6ff)

`attributes:`の下の`curriculum-log`に`curriculum_id:`ではなく、`curriculum:`とすることでバリデーションメッセージの日本語化に成功。謎は残る。