### PR TITLE
レイアウトなど微調整

### DIFF
--- a/app/assets/stylesheets/_font.scss
+++ b/app/assets/stylesheets/_font.scss
@@ -16,7 +16,7 @@ body {
 }
 
 .top {
-  font-size: 90px;
+  font-size: 70px;
   font-family: 'Cantata One', serif;
   display: flex;
 }

--- a/app/views/curriculum_logs/_form.html.erb
+++ b/app/views/curriculum_logs/_form.html.erb
@@ -23,7 +23,7 @@
                   <td><%= f.text_area :body, class: 'form-control' %></td>
                 </tr>
                 <tr>
-                  <th></th>
+                  <th style="text-align: center;"><%= f.label '勉強時間' , class: "col-form-label"%></th>
                   <td>
                     <div style="display: inline-block;">
                       <%= f.text_field :hour, class: 'form-control' %></div>

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -1,7 +1,7 @@
 <div class = "container mt-5">
   <div class = "row justify-content-center">
-      <div class="d-flex flex-column justify-content-center me-5 mt-5 col-md-8" style="width: 379px; height: 154px;">
-        <div class ="me-5">
+      <div class="d-flex flex-column justify-content-center m-5 col-md-6" style="width: 379px; height: 154px;">
+        <div class ="me-5 mx-auto text-center">
           <h1 class = "top">Loguma</h1>
         </div>
         <div class = "text-center mt-5">
@@ -12,8 +12,8 @@
           <% end %>
         </div>
       </div>
-      <div class= "col-5  col-sm-8">
-        <%= image_tag 'book_top.png',size: "552x338",class: "rounded-3"%>
+      <div class= "col-5  col-sm-6">
+        <%= image_tag 'book_top.png',size: "552x338",class: "rounded-3 img-fluid"%>
       </div>
   </div>
 </div>

--- a/app/views/profiles/_profile.html.erb
+++ b/app/views/profiles/_profile.html.erb
@@ -3,7 +3,7 @@
 </div>
 <table class="table">
   <tr>
-    <th>total</th>
+    <th>累計勉強時間</th>
     <td><%= total_study_time(current_user) %></td>
   </tr>
   <tr>
@@ -15,19 +15,19 @@
     <td><%= remaining_time_to_1000_hours(current_user) %></td>
   </tr>
   <tr>
-    <th scope="row">name</th>
+    <th scope="row"><%= Profile.human_attribute_name(:name) %></th>
     <td><%= @profile.name %></td>
   </tr>
   <tr>
-    <th scope="row">email</th>
+    <th scope="row"><%= User.human_attribute_name(:email)%></th>
     <td><%= @user.email %></td>
   </tr>
   <tr>
-    <th scope="row">languages</th>
+    <th scope="row"><%= Profile.human_attribute_name(:language)%></th>
     <td><%= @profile.language %></td>
   </tr>
   <tr>
-    <th scope="row">introduction</th>
+    <th scope="row"><%= Profile.human_attribute_name(:introduction)%></th>
     <td><%= @profile.introduction %></td>
   </tr>
 </table>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -16,10 +16,12 @@
         </div>
       <% end %>
       <div class='text-center'>
-        <%= link_to auth_at_provider_path(provider: :github), class: "btn btn-light mt-5 py-2 px-3", style:"background-color:#0d6efd; color:#fff;" do %>
+        <%= link_to auth_at_provider_path(provider: :github), class: "btn btn-light mt-5 py-2 px-3", style:"background-color:#123A28; color:#fff;" do %>
           <i class="bi bi-github me-2"></i>GitHubでログイン
         <% end %>
-        <%= link_to 'Login with Google', auth_at_provider_path(provider: :google) %>
+        <%= link_to auth_at_provider_path(provider: :google), class: "btn btn-light mt-5 py-2 px-3", style:"background-color:#0d6efd; color:#fff;" do %>
+          <i class="bi bi-google me-2"></i>Googleでログイン
+        <% end %>
       </div>
       <div class='text-center mt-5'>
         <%= link_to '登録ページへ', new_user_path, class: "me-3" %>


### PR DESCRIPTION
1. プロフィール画面のカラム名を日本語化
<img width="475" alt="image" src="https://github.com/kucyaman/team_project/assets/133073514/3ac619b3-1411-4c01-9a16-f6747ff3478d">

2. ログ入力フォームの「勉強時間」ラベルの追加
<img width="539" alt="image" src="https://github.com/kucyaman/team_project/assets/133073514/76c48531-78bd-43dd-840d-ab7e1600629e">

3. top画面の画像を画面サイズに応じて変更、およびアプリ名フォントサイズを70pxに変更
<img width="472" alt="image" src="https://github.com/kucyaman/team_project/assets/133073514/a68bf1a4-3f63-4201-b261-b40be31ae940">

4. githubログインとgoogleログインボタンを変更
<img width="394" alt="image" src="https://github.com/kucyaman/team_project/assets/133073514/6e51b00c-a425-43d9-b438-b8f4332e287b">
